### PR TITLE
Dependency Loading Implementation (ALC)

### DIFF
--- a/AspNetCore.Modularity.sln
+++ b/AspNetCore.Modularity.sln
@@ -26,7 +26,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyMainWebApplication", "san
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyFirstPlugin", "sandbox\MyFirstPlugin\MyFirstPlugin.csproj", "{F3EBCA12-E100-4F05-B087-796208182D10}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Modularity.Core.Abstractions", "src\Modularity.Core.Abstractions\Modularity.Core.Abstractions.csproj", "{38C76CF3-D53C-478C-BE8B-FFEB0FD419FF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Modularity.Core.Abstractions", "src\Modularity.Core.Abstractions\Modularity.Core.Abstractions.csproj", "{38C76CF3-D53C-478C-BE8B-FFEB0FD419FF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/sandbox/MyMainWebApplication/Plugins/plugins.json
+++ b/sandbox/MyMainWebApplication/Plugins/plugins.json
@@ -2,11 +2,14 @@
   {
     "Name": "MyFirstPlugin",
     "IsActive": true,
-    "LoadAllDependencies" :  true
+    "LoadAllDependencies": true,
   },
   {
     "Name": "MySecondPlugin",
     "IsActive": false,
-    "LoadAllDependencies" :  true
+    "LoadAllDependencies": true,
+    "Files": [
+      "C:\\Users\\enisn\\.nuget\\packages\\newtonsoft.json\\12.0.2\\lib\\netstandard2.0\\Newtonsoft.Json.dll"
+    ]
   }
 ]

--- a/src/Modularity.AspNetCore.Abstractions/Modularity.AspNetCore.Abstractions.csproj
+++ b/src/Modularity.AspNetCore.Abstractions/Modularity.AspNetCore.Abstractions.csproj
@@ -9,7 +9,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/enisn/Modularity.AspNetCore</PackageProjectUrl>
     <RepositoryUrl>https://github.com/enisn/Modularity.AspNetCore</RepositoryUrl>
-    <Version>0.2.0-pre</Version>
+    <Version>0.3.1-pre</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Modularity.AspNetCore/AspNetCoreModulesManager.cs
+++ b/src/Modularity.AspNetCore/AspNetCoreModulesManager.cs
@@ -22,7 +22,7 @@ namespace Modularity.AspNetCore
                 {
                     moduleStartups = Modules
                         .Where(x => x is IModuleStartup)
-                        .Select(s => s.EntryObject as IModuleStartup)
+                        .SelectMany(s => s.EntryObjects.Cast<IModuleStartup>())
                         .ToList();
                 }
                 return moduleStartups;

--- a/src/Modularity.AspNetCore/Configuration/ConfigurationExtensions.cs
+++ b/src/Modularity.AspNetCore/Configuration/ConfigurationExtensions.cs
@@ -20,10 +20,10 @@ namespace Modularity.AspNetCore.Configuration
 
             AspNetCoreModulesManager.Current.LoadModules(ModularityOptions);
 
-            foreach (var module in AspNetCoreModulesManager.Current.Modules)
-            {
-                builder.AddApplicationPart(module.Assembly);
-            }
+            foreach (var module in AspNetCoreModulesManager.Current.Modules)            
+                if (module.Assembly != null)
+                    builder.AddApplicationPart(module.Assembly);
+            
             return builder;
         }
 

--- a/src/Modularity.AspNetCore/Modularity.AspNetCore.csproj
+++ b/src/Modularity.AspNetCore/Modularity.AspNetCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <Authors>enisn</Authors>
-    <Version>0.2.0-pre</Version>
+    <Version>0.3.1-pre</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Description>This library allows to import your class libraries with controllers to your main project. So you can easily use plug-in &amp; plug-out your features.</Description>
     <PackageTags>AspNetCore,Plugin,Module,AspNet Plugin,Modularity</PackageTags>

--- a/src/Modularity.Core.Abstractions/IModule.cs
+++ b/src/Modularity.Core.Abstractions/IModule.cs
@@ -12,7 +12,7 @@ namespace Modularity.Core.Abstractions
         string Name { get; }
         string AssemblyName { get; }
         Assembly Assembly { get; }
-        Exception Exception { get; }
-        IEntryObject EntryObject { get; set; }
+        IList<Exception> Exceptions { get; }
+        IList<IEntryObject> EntryObjects { get; }
     }
 }

--- a/src/Modularity.Core.Abstractions/Modularity.Core.Abstractions.csproj
+++ b/src/Modularity.Core.Abstractions/Modularity.Core.Abstractions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.2.0-pre</Version>
+    <Version>0.3.1-pre</Version>
     <Authors>enisn</Authors>
     <Company>enisn</Company>
     <Description>Abstractions of Modularity.Core</Description>

--- a/src/Modularity.Core/Loaders/FileModuleLoader.cs
+++ b/src/Modularity.Core/Loaders/FileModuleLoader.cs
@@ -29,7 +29,7 @@ namespace Modularity.Core.Loaders
                     {
                         Assembly = assembly,
                         AssemblyName = assembly.FullName,
-                        EntryObject = (IEntryObject)Activator.CreateInstance(entryObjectType),
+                        EntryObjects = new[] { (IEntryObject)Activator.CreateInstance(entryObjectType) },
                         Exception = null,
                         Name = assembly.GetCustomAttribute<AssemblyTitleAttribute>()?.Title
                     };
@@ -92,7 +92,6 @@ namespace Modularity.Core.Loaders
                             module.Assembly = assembly;
                             module.AssemblyName = assembly.FullName;
                             module.EntryObjects = assembly.GetTypes().Where(x => typeof(IEntryObject).IsAssignableFrom(x)).Select(s => (IEntryObject)Activator.CreateInstance(s)).ToList();
-                            module.EntryObject = module.EntryObjects?.FirstOrDefault();
                             module.Name = config.Name;
                         }
                         else

--- a/src/Modularity.Core/Loaders/FileModuleLoader.cs
+++ b/src/Modularity.Core/Loaders/FileModuleLoader.cs
@@ -2,9 +2,11 @@
 using Modularity.Core.Helpers;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Loader;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -51,43 +53,57 @@ namespace Modularity.Core.Loaders
 
             foreach (var config in configs.Where(x => x.IsActive))
             {
-                Module module;
+                Module module = new Module
+                {
+                    Assemblies = new List<Assembly>(),
+                    Name = config.Name,
+                    Exception = null,
+                    EntryObjects = new List<IEntryObject>()
+                };
+
                 try
                 {
-                    module = new Module
-                    {
-                        Assemblies = new List<Assembly>(),
-                        Name = config.Name,
-                        Exception = null,
-                        EntryObjects = new List<IEntryObject>()
-                    };
+                    if (config.Files != null && config.Files.Length > 0)
+                        foreach (var file in config.Files)
+                            try
+                            {
+                                using (var ms = new MemoryStream(File.ReadAllBytes(file)))
+                                    AssemblyLoadContext.Default.LoadFromStream(ms);
+                            }
+                            catch (Exception ex)
+                            {
+                                Debug.WriteLine(ex.ToString());
+                                module.Exceptions?.Add(ex);
+                            }
 
-                    var files = config.Files;
-                    if (files == null || files.Length == 0)
-                        files = Directory.GetFiles(Path.Combine(directory, config.Name), "*.dll");
+                    var mainAssemblyName = Path.Combine(directory, config.Name, config.Name + ".dll");
 
-                    foreach (var file in files)
+                    foreach (var file in Directory.GetFiles(Path.Combine(directory, config.Name), "*.dll"))
                     {
+                        var isMainAssembly = file == mainAssemblyName;
+                        if (!config.LoadAllDependencies && !isMainAssembly)
+                            continue;
 
                         var bytes = File.ReadAllBytes(file);
-                        var assembly = Assembly.Load(bytes);
 
-                        module.Assemblies.Add(assembly);
-
-                        var entryObjectTypes = assembly.GetTypes().Where(x => x.IsClass && typeof(IEntryObject).IsAssignableFrom(x)).ToList();
-                        if (entryObjectTypes != null && entryObjectTypes.Count > 0)
+                        if (isMainAssembly)
                         {
-                            foreach (var entryobjectType in entryObjectTypes)
-                                module.EntryObjects.Add((IEntryObject)Activator.CreateInstance(entryobjectType));
-
-                            module.EntryObject = (IEntryObject)Activator.CreateInstance(entryObjectTypes.FirstOrDefault());
+                            var assembly = Assembly.Load(bytes);
                             module.Assembly = assembly;
-                            if (!config.LoadAllDependencies)
-                                break;
+                            module.AssemblyName = assembly.FullName;
+                            module.EntryObjects = assembly.GetTypes().Where(x => typeof(IEntryObject).IsAssignableFrom(x)).Select(s => (IEntryObject)Activator.CreateInstance(s)).ToList();
+                            module.EntryObject = module.EntryObjects?.FirstOrDefault();
+                            module.Name = config.Name;
+                        }
+                        else
+                        {
+                            using (var ms = new MemoryStream(bytes))
+                            {
+                                var assembly = AssemblyLoadContext.Default.LoadFromStream(ms);
+                                module.Assemblies.Add(assembly);
+                            }
                         }
                     }
-
-
                 }
                 catch (Exception ex)
                 {

--- a/src/Modularity.Core/Modularity.Core.csproj
+++ b/src/Modularity.Core/Modularity.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.2.0-pre</Version>
+    <Version>0.3.1-pre</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>enisn</Authors>
     <PackageProjectUrl>https://github.com/enisn/Modularity.AspNetCore</PackageProjectUrl>

--- a/src/Modularity.Core/Modularity.Core.csproj
+++ b/src/Modularity.Core/Modularity.Core.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Modularity.Core/Module.cs
+++ b/src/Modularity.Core/Module.cs
@@ -16,7 +16,6 @@ namespace Modularity.Core
         public IList<Assembly> Assemblies { get; set; }
         public Exception Exception { get; set; }
         public IList<Exception> Exceptions { get; set; } = new List<Exception>();
-        public IList<IEntryObject> EntryObjects { get; set; } 
-        public IEntryObject EntryObject { get; set; }
+        public IList<IEntryObject> EntryObjects { get; set; }
     }
 }

--- a/src/Modularity.Core/Module.cs
+++ b/src/Modularity.Core/Module.cs
@@ -15,6 +15,7 @@ namespace Modularity.Core
         public Assembly Assembly { get; set; }
         public IList<Assembly> Assemblies { get; set; }
         public Exception Exception { get; set; }
+        public IList<Exception> Exceptions { get; set; } = new List<Exception>();
         public IList<IEntryObject> EntryObjects { get; set; } 
         public IEntryObject EntryObject { get; set; }
     }


### PR DESCRIPTION
Module's Dependencies will be loaded using **AssemblyLoadContext** (ALC).
So all `.dll` files in same folder with Plugin main `.dll` will be loaded to main **AppDomain** and they'll be callable at runtime.